### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [ 18.x, 20.x, 23.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run CI script
+        run: npm run ci

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "ci": "npm run lint && npm run test && npm run build"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",


### PR DESCRIPTION
Fixes #9

Add GitHub action for CI to perform linting, testing, and building.

* **package.json**
  - Add `ci` script to run `lint`, `test`, and `build` scripts.

* **.github/workflows/ci.yml**
  - Create GitHub action to run on `push` and `pull_request` events.
  - Set up Node.js environment.
  - Install dependencies.
  - Run `ci` script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/graphql-practice/pull/10?shareId=aa137458-6302-4bf2-8dd8-252e7b1487ce).