### PR TITLE
Add Docker volume for PostgreSQL data persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ This project is a simple book review API built with NestJS. It allows users to c
    ```
 3. The PostgreSQL database will be available at `localhost:5432`.
 4. Access pgAdmin at `http://localhost:5050` with the default email `admin@admin.com` and password `admin`.
+5. The PostgreSQL data will persist across container restarts due to the volume configuration.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - "5432:5432"
     networks:
       - mynetwork
+    volumes:
+      - pgdata:/var/lib/postgresql/data
 
   pgadmin:
     image: dpage/pgadmin4:latest
@@ -27,3 +29,6 @@ services:
 networks:
   mynetwork:
     driver: bridge
+
+volumes:
+  pgdata:


### PR DESCRIPTION
Add volume configuration to persist PostgreSQL data in Docker.

* **docker-compose.yml**
  - Add a volume named `pgdata` to the PostgreSQL service.
  - Map the volume to the PostgreSQL data directory `/var/lib/postgresql/data`.
  - Define the `pgdata` volume under the `volumes` section.

* **README.md**
  - Add instruction about PostgreSQL data persistence due to the volume configuration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/graphql-practice/pull/11?shareId=873aef8c-acc5-438c-ba19-0ab2734afe9e).