### PR TITLE
Containerize the app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use the node:14 image as the base image
+FROM node:14
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the current directory contents to /app
+COPY . /app
+
+# Install dependencies and generate Prisma client
+RUN npm install && npx prisma generate
+
+# Expose port 8080
+EXPOSE 8080
+
+# Run the application
+CMD ["npm", "run", "start:dev"]

--- a/README.md
+++ b/README.md
@@ -37,3 +37,25 @@ This project is a simple book review API built with NestJS. It allows users to c
 3. The PostgreSQL database will be available at `localhost:5432`.
 4. Access pgAdmin at `http://localhost:5050` with the default email `admin@admin.com` and password `admin`.
 5. The PostgreSQL data will persist across container restarts due to the volume configuration.
+
+## Building and Running the Application Docker Container
+
+1. Build the Docker image for the application:
+   ```bash
+   docker build -t book-review-app .
+   ```
+2. Run the Docker container for the application:
+   ```bash
+   docker run -d -p 8080:8080 --name book-review-app book-review-app
+   ```
+
+## Updated Usage with Docker
+
+1. Start the Docker containers:
+   ```bash
+   docker-compose up -d
+   ```
+2. The API will be available at `http://localhost:8080`.
+3. The PostgreSQL database will be available at `localhost:5432`.
+4. Access pgAdmin at `http://localhost:5050` with the default email `admin@admin.com` and password `admin`.
+5. The PostgreSQL data will persist across container restarts due to the volume configuration.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,22 @@ services:
     networks:
       - mynetwork
 
+  app:
+    image: node:latest
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: >
+      sh -c "npm install &&
+             npx prisma generate &&
+             npm run start:dev"
+    depends_on:
+      - postgres
+    ports:
+      - "8080:8080"
+    networks:
+      - mynetwork
+
 networks:
   mynetwork:
     driver: bridge


### PR DESCRIPTION
Fixes #16

Containerize the application with dependencies on PostgreSQL and pgAdmin.

* **docker-compose.yml**:
  - Add a service for the application using the `node:latest` image.
  - Set the working directory to `/app` and copy the current directory contents to `/app`.
  - Install dependencies, generate Prisma client, and run the application using `npm install`, `npx prisma generate`, and `npm run start:dev`.
  - Add a dependency on the `postgres` service.
  - Expose port 8080.
* **Dockerfile**:
  - Use the `node:14` image as the base image.
  - Set the working directory to `/app`.
  - Copy the current directory contents to `/app`.
  - Install dependencies and generate Prisma client.
  - Expose port 8080.
  - Run the application using `npm run start:dev`.
* **README.md**:
  - Add instructions to build and run the Docker container for the application.
  - Update the usage section to reflect the new Docker setup.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/graphql-practice/pull/17?shareId=e1bac764-dd54-43da-8b85-533bd521b908).