### PR TITLE
Add GitHub action to build app image

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,30 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/book-review-app:latest

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -20,7 +20,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,7 +26,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the node:14 image as the base image
-FROM node:14
+FROM node:latest
 
 # Set the working directory to /app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -59,3 +59,12 @@ This project is a simple book review API built with NestJS. It allows users to c
 3. The PostgreSQL database will be available at `localhost:5432`.
 4. Access pgAdmin at `http://localhost:5050` with the default email `admin@admin.com` and password `admin`.
 5. The PostgreSQL data will persist across container restarts due to the volume configuration.
+
+## Using the GitHub Action to Build the App Image
+
+1. Ensure you have a Docker registry account (e.g., Docker Hub).
+2. Update the GitHub repository secrets with your Docker registry credentials:
+   - `DOCKER_USERNAME`: Your Docker registry username.
+   - `DOCKER_PASSWORD`: Your Docker registry password.
+3. The GitHub action will automatically build and push the Docker image to the registry on every push to the `main` branch.
+4. You can find the built image in your Docker registry account.


### PR DESCRIPTION
Fixes #18

Add a GitHub action to build and push the app image.

* **New GitHub Action**: Create a new GitHub action in `.github/workflows/build-image.yml` to build and push the Docker image to a Docker registry on every push to the `main` branch.
* **README Update**: Add instructions in `README.md` for using the new GitHub action, including steps to set up Docker registry credentials and details on how the action works.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/graphql-practice/pull/19?shareId=947533a8-26e8-4568-8517-c88ae4079bed).