### PR TITLE
Add Docker image build on pull request

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -66,5 +66,5 @@ This project is a simple book review API built with NestJS. It allows users to c
 2. Update the GitHub repository secrets with your Docker registry credentials:
    - `DOCKER_USERNAME`: Your Docker registry username.
    - `DOCKER_PASSWORD`: Your Docker registry password.
-3. The GitHub action will automatically build and push the Docker image to the registry on every push to the `main` branch.
+3. The GitHub action will automatically build and push the Docker image to the registry on every push to the `main` branch and on every pull request to the `main` branch.
 4. You can find the built image in your Docker registry account.


### PR DESCRIPTION
Update the GitHub action to build Docker image on pull requests.

* **README.md**
  - Update the "Using the GitHub Action to Build the App Image" section to include pull requests.

* **.github/workflows/build-image.yml**
  - Add `pull_request` trigger to the `on` section to build Docker image on pull requests to the `main` branch.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/graphql-practice/pull/20?shareId=af6349af-8ea2-4d29-bff0-ce9e9a39707c).