### PR TITLE
Update DATABASE_URL environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DATABASE_URL="postgresql://admin:admin@localhost:5432/mydatabase?schema=public"
+DATABASE_URL="postgresql://admin:admin@postgres:5432/mydatabase?schema=public"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
   app:
     image: node:latest
     working_dir: /app
+    environment:
+      DATABASE_URL: "postgresql://admin:admin@postgres:5432/mydatabase?schema=public"
     volumes:
       - .:/app
     command: >


### PR DESCRIPTION
Fixes #26

Update the `DATABASE_URL` environment variable to point to the PostgreSQL image.

* **docker-compose.yml**
  - Add `DATABASE_URL` environment variable to the `app` service with the value `postgresql://admin:admin@postgres:5432/mydatabase?schema=public`.

* **.env**
  - Update the `DATABASE_URL` environment variable to `postgresql://admin:admin@postgres:5432/mydatabase?schema=public`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/graphql-practice/pull/27?shareId=1aae30d9-bd9c-4923-9fbb-f32c09d2e98b).