### PR TITLE
Fix BooksResolver test by adding PrismaService to providers

### DIFF
--- a/src/books/books.module.ts
+++ b/src/books/books.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { BooksService } from './books.service';
 import { BooksResolver } from './books.resolver';
+import { PrismaService } from '../prisma.service';
 
 @Module({
-    providers: [BooksResolver, BooksService],
+    providers: [BooksResolver, BooksService, PrismaService],
 })
 export class BooksModule {}

--- a/src/books/books.resolver.spec.ts
+++ b/src/books/books.resolver.spec.ts
@@ -1,13 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BooksResolver } from './books.resolver';
 import { BooksService } from './books.service';
+import { PrismaService } from '../prisma.service';
 
 describe('BooksResolver', () => {
     let resolver: BooksResolver;
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
-            providers: [BooksResolver, BooksService],
+            providers: [BooksResolver, BooksService, PrismaService],
         }).compile();
 
         resolver = module.get<BooksResolver>(BooksResolver);


### PR DESCRIPTION
Fix the failing `BooksResolver` test by resolving the `PrismaService` dependency.

* Add `PrismaService` to the `providers` array in `src/books/books.module.ts`.
* Add `PrismaService` to the `providers` array in the `TestingModule` in `src/books/books.resolver.spec.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/graphql-practice/pull/34?shareId=dcae95ff-bb87-4913-a907-339171bc7df2).