### PR TITLE
Add info about all access points, including GraphQL Playground, pgAdmin, and Swagger API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ This project is a simple book review API built with NestJS. It allows users to c
 4. Access pgAdmin at `http://localhost:5050` with the default email `admin@admin.com` and password `admin`.
 5. The PostgreSQL data will persist across container restarts due to the volume configuration.
 
+## Access Points
+
+- GraphQL Playground: `http://localhost:8080/graphql`
+- pgAdmin: `http://localhost:5050`
+- Swagger API Docs: `http://localhost:8080/docs`
+
 ## Setting Up the App Without Docker
 
 1. Ensure you have PostgreSQL installed and running on your machine.


### PR DESCRIPTION
Add information about access points in the README.md file.

* Add a new section "Access Points" with details on:
  - GraphQL Playground: `http://localhost:8080/graphql`
  - pgAdmin: `http://localhost:5050`
  - Swagger API Docs: `http://localhost:8080/docs`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/graphql-practice/pull/38?shareId=9ffb88b7-2819-4e42-96b3-e0aa38ef59c2).