### PR TITLE
Add server to services list in docker-compose.yml, it builds our app image

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ This project is a simple book review API built with NestJS. It allows users to c
 4. Access pgAdmin at `http://localhost:5050` with the default email `admin@admin.com` and password `admin`.
 5. The PostgreSQL data will persist across container restarts due to the volume configuration.
 6. Access Prisma Studio at `http://localhost:5555` for database management.
+7. Start the server service:
+   ```bash
+   docker-compose up -d server
+   ```
+8. The server will be available at `http://localhost:8080`.
 
 ## Access Points
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,18 @@ services:
     networks:
       - prisma-network
 
+  server:
+    build:
+      context: .
+    working_dir: /app
+    command: npm run start:prod
+    depends_on:
+      - postgres
+    ports:
+      - "8080:8080"
+    networks:
+      - mynetwork
+
 networks:
   mynetwork:
     driver: bridge


### PR DESCRIPTION
Add a `server` service to the `docker-compose.yml` file to build and run the app image.

* **docker-compose.yml**
  - Add a `server` service that builds the app image using the `Dockerfile`.
  - Set the `build` context to the current directory.
  - Set the `working_dir` to `/app`.
  - Set the `command` to start the app in production mode.
  - Set the `depends_on` to `postgres`.
  - Expose port `8080` for the server service.
  - Add the `server` service to the `mynetwork` network.

* **README.md**
  - Add instructions for setting up and running the `server` service using Docker.
  - Mention that the server will be available at `http://localhost:8080`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Phastboy/graphql-practice/pull/44?shareId=ab7219de-8b4b-451f-a559-6da655f79ae0).